### PR TITLE
Init command functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work.sum
 
 # visual-studio code "vscode" workspace
 .vscode
+
+# dodl workspaces (just in case...)
+.dodl

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ go.work.sum
 
 # dodl workspaces (just in case...)
 .dodl
+
+# build artifacts
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+BUILD_DIR=build
+BINARY_NAME=dodl
+PKG=./...
+PLATFORMS=linux darwin windows
+ARCHITECTURES=amd64 arm64
+
+default: build
+
+build: test
+	@echo "Building for all platforms and architectures..."
+	@for GOOS in $(PLATFORMS); do \
+		for GOARCH in $(ARCHITECTURES); do \
+			echo "Building for $$GOOS/$$GOARCH..."; \
+			mkdir -p $(BUILD_DIR) && \
+			GOOS=$$GOOS GOARCH=$$GOARCH go build -o $(BUILD_DIR)/$(BINARY_NAME)-$$GOOS-$$GOARCH; \
+		done; \
+	done
+
+test: vet
+	@echo "Running tests..."
+	go test $(PKG) -v
+
+fmt:
+	@echo "Running code formatting..."
+	go fmt $(PKG)
+
+lint:
+	@echo "Running linter..."
+	golangci-lint run
+
+vet: fmt lint
+	@echo "Running go vet..."
+	go vet $(PKG)
+
+clean:
+	@echo "Cleaning up..."
+	rm -rf $(BUILD_DIR)
+
+deps:
+	@echo "Installing dependencies..."
+	go mod tidy
+
+install: build
+	@echo "Installing the binary..."
+	go install ./
+
+.PHONY: build test fmt lint vet clean deps install

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -38,7 +38,7 @@ func runInitE(args []string, wdProv wd.WorkingDirProvider) error {
 		Command: "init",
 		Args:    args,
 		Flags: map[string]interface{}{
-			"directory": targetDir,
+			"targetDirectory": targetDir,
 		},
 		EntryPoint: workingDir,
 	}

--- a/filesystem/mkdir.go
+++ b/filesystem/mkdir.go
@@ -1,0 +1,23 @@
+package filesystem
+
+import (
+	"fmt"
+	"os"
+)
+
+// MkDir creates a directory at the specified path if it does not already exist.
+func MkDir(path string) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("tried to create directory %q but a file with the same name already exists", path)
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	err = os.MkdirAll(path, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/filesystem/mkdir_test.go
+++ b/filesystem/mkdir_test.go
@@ -1,0 +1,84 @@
+package filesystem_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matthewchivers/dodl/filesystem"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMkDir(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingDirs  []string
+		existingFiles []string
+		newDirPath    string
+		expectedErr   bool
+	}{
+		{
+			name:          "create new directory",
+			existingDirs:  []string{},
+			existingFiles: []string{},
+			newDirPath:    "newdir",
+			expectedErr:   false,
+		},
+		{
+			name:          "create directory that already exists",
+			existingDirs:  []string{"existingdir"},
+			existingFiles: []string{},
+			newDirPath:    "existingdir",
+			expectedErr:   false,
+		},
+		{
+			name:          "fail to create directory where file exists",
+			existingDirs:  []string{},
+			existingFiles: []string{"existingfile"},
+			newDirPath:    "existingfile",
+			expectedErr:   true,
+		},
+		{
+			name:          "create nested directories",
+			existingDirs:  []string{},
+			existingFiles: []string{},
+			newDirPath:    filepath.Join("parent", "child"),
+			expectedErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseDir, err := os.MkdirTemp("", "testmkdir")
+			assert.NoError(t, err, "failed to create temp dir")
+
+			defer os.RemoveAll(baseDir)
+			for _, existingDir := range tt.existingDirs {
+				path := filepath.Join(baseDir, existingDir)
+				err := os.Mkdir(path, os.ModePerm)
+				assert.NoError(t, err, "failed to create existing directory")
+			}
+
+			for _, existingFile := range tt.existingFiles {
+				path := filepath.Join(baseDir, existingFile)
+				err := os.WriteFile(path, []byte("test"), os.ModePerm)
+				assert.NoError(t, err, "failed to create existing file")
+			}
+
+			targetDir := filepath.Join(baseDir, tt.newDirPath)
+
+			err = filesystem.MkDir(targetDir)
+			if tt.expectedErr {
+				assert.Error(t, err, "expected an error but got none")
+			} else {
+				assert.NoError(t, err, "unexpected error occurred")
+			}
+
+			if !tt.expectedErr {
+				info, statErr := os.Stat(targetDir)
+				assert.NoError(t, statErr, "expected directory to be created, but got an error")
+				assert.True(t, info.IsDir(), "expected a directory but found something else: %v", targetDir)
+			}
+		})
+	}
+}

--- a/workspace/initialise.go
+++ b/workspace/initialise.go
@@ -1,0 +1,37 @@
+package workspace
+
+import (
+	"path/filepath"
+
+	"github.com/matthewchivers/dodl/filesystem"
+)
+
+func Initialise(targetDir string) error {
+	workspaceRoot := getRootPath(targetDir)
+
+	err := createWorkspaceRoot(targetDir)
+	if err != nil {
+		return err
+	}
+
+	err = createTemplatesDir(workspaceRoot)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getRootPath(targetDir string) string {
+	return filepath.Join(targetDir, ".dodl")
+}
+
+func createWorkspaceRoot(targetDir string) error {
+	workspaceRootPath := filepath.Join(targetDir, ".dodl")
+	return filesystem.MkDir(workspaceRootPath)
+}
+
+func createTemplatesDir(workspaceRoot string) error {
+	templatesDirPath := filepath.Join(workspaceRoot, "templates")
+	return filesystem.MkDir(templatesDirPath)
+}

--- a/workspace/initialise_test.go
+++ b/workspace/initialise_test.go
@@ -1,0 +1,90 @@
+package workspace_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/matthewchivers/dodl/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitialise(t *testing.T) {
+	tests := []struct {
+		name          string
+		existingDirs  []string
+		existingFiles []string
+		targetDir     string
+		expectedErr   bool
+	}{
+		{
+			name:          "initialise new workspace",
+			existingDirs:  []string{},
+			existingFiles: []string{},
+			targetDir:     "workspace1",
+			expectedErr:   false,
+		},
+		{
+			name:          "re-initialise existing workspace",
+			existingDirs:  []string{filepath.Join("workspace2", ".dodl"), filepath.Join("workspace2", ".dodl", "templates")},
+			existingFiles: []string{},
+			targetDir:     "workspace2",
+			expectedErr:   false,
+		},
+		{
+			name:          "fail to initialise where file exists",
+			existingDirs:  []string{"workspace3"},
+			existingFiles: []string{filepath.Join("workspace3", ".dodl")},
+			targetDir:     "workspace3",
+			expectedErr:   true,
+		},
+		{
+			name:          "initialise nested workspace",
+			existingDirs:  []string{"parent_workspace", ".dodl"},
+			existingFiles: []string{},
+			targetDir:     filepath.Join("parent_workspace", "nested_workspace"),
+			expectedErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseDir, err := os.MkdirTemp("", "testinitialise")
+			assert.NoError(t, err, "failed to create temp dir")
+			defer os.RemoveAll(baseDir)
+
+			for _, existingDir := range tt.existingDirs {
+				path := filepath.Join(baseDir, existingDir)
+				err := os.MkdirAll(path, os.ModePerm)
+				assert.NoError(t, err, "failed to create existing directory")
+			}
+
+			for _, existingFile := range tt.existingFiles {
+				path := filepath.Join(baseDir, existingFile)
+				err := os.WriteFile(path, []byte("test"), os.ModePerm)
+				assert.NoError(t, err, "failed to create existing file")
+			}
+
+			targetDir := filepath.Join(baseDir, tt.targetDir)
+
+			err = workspace.Initialise(targetDir)
+			if tt.expectedErr {
+				assert.Error(t, err, "expected an error but got none")
+			} else {
+				assert.NoError(t, err, "unexpected error occurred")
+			}
+
+			if !tt.expectedErr {
+				workspaceRoot := filepath.Join(targetDir, ".dodl")
+				info, statErr := os.Stat(workspaceRoot)
+				assert.NoError(t, statErr, "expected workspace root to be created, but got an error")
+				assert.True(t, info.IsDir(), "expected a directory but found something else: %v", workspaceRoot)
+
+				templatesDir := filepath.Join(workspaceRoot, "templates")
+				templatesInfo, templatesErr := os.Stat(templatesDir)
+				assert.NoError(t, templatesErr, "expected templates directory to be created, but got an error")
+				assert.True(t, templatesInfo.IsDir(), "expected a directory but found something else: %v", templatesDir)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added functionality for the "init" command.

* Added Makefile (with build, test, install functionality, etc.)
* Removed init command placeholder and added init functionality in its place
    * Now creates a `.dodl` directory in the specified directory, and a `templates` directory within that `.dodl` directory.
* Added filesystem package with `MkDir` function to support workspace initialisation