### PR TITLE
(feat) (breaking) changed config to have arrays for directory patterns

### DIFF
--- a/cmd/create/create_test.go
+++ b/cmd/create/create_test.go
@@ -43,7 +43,7 @@ document_types:
   journal:
     template_file: "journal.md"
     file_name_pattern: "{{.Today}}-journal.md"
-    directory_pattern: "{{.Today}}-dir"
+    directory_pattern: ["{{.Today}}-dir"]
 `
 
 	configFilePath := filepath.Join(rootDir, ".dodl", "config.yaml")

--- a/internal/core/create.go
+++ b/internal/core/create.go
@@ -42,10 +42,15 @@ func (c *CreateCommand) Execute() error {
 		return err
 	}
 
-	dirname, err := templating.RenderTemplate(c.DocType.DirectoryPattern, data)
-	if err != nil {
-		return err
+	dirParts := []string{}
+	for _, part := range c.DocType.DirectoryPattern {
+		dirPart, err := templating.RenderTemplate(part, data)
+		if err != nil {
+			return err
+		}
+		dirParts = append(dirParts, dirPart)
 	}
+	dirname := filepath.Join(dirParts...)
 
 	templateData, err := c.Workspace.LoadTemplate(c.DocType.TemplateFile)
 	if err != nil {

--- a/internal/core/create_test.go
+++ b/internal/core/create_test.go
@@ -44,10 +44,14 @@ func createMockAppContext(testDir string, mockStartTime time.Time) *AppContext {
 // createMockDocumentType creates a mock document type for testing
 func createMockDocumentType() config.DocumentType {
 	return config.DocumentType{
-		FileNamePattern:  "notes/{{ .Today | date \"2006-01-02\" }}-{{ .DocName }}.md",
-		DirectoryPattern: "docs/{{ .Today | date \"2006\" }}/{{ .Today | date \"January\" }}",
-		TemplateFile:     "test_template.md",
-		CustomFields:     map[string]interface{}{"CustomField": "Example Custom Field"},
+		FileNamePattern: "{{ .Today | date \"2006-01-02\" }}-{{ .DocName }}.md",
+		DirectoryPattern: []string{
+			"docs",
+			"{{ .Today | date \"2006\" }}",
+			"{{ .Today | date \"January\" }}",
+		},
+		TemplateFile: "test_template.md",
+		CustomFields: map[string]interface{}{"CustomField": "Example Custom Field"},
 	}
 }
 
@@ -94,7 +98,7 @@ func TestCreateCommand_Execute(t *testing.T) {
 	require.NoError(t, cmd.Execute(), "Failed to execute create command")
 
 	expectedDirPath := filepath.Join(testDir, "docs", mockStartTime.Format("2006"), mockStartTime.Format("January"))
-	expectedFilePath := filepath.Join(expectedDirPath, "notes", fmt.Sprintf("%s-TestDocument.md", mockStartTime.Format("2006-01-02")))
+	expectedFilePath := filepath.Join(expectedDirPath, fmt.Sprintf("%s-TestDocument.md", mockStartTime.Format("2006-01-02")))
 
 	expectedContent := fmt.Sprintf(`Document Title: TestDocument
 Date: %s

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ type DocumentType struct {
 
 	// DirectoryPattern is the pattern to use when generating the directory for a document.
 	// The pattern is a Go template string, and the directory is relative to the workspace root.
-	DirectoryPattern string `yaml:"directory_pattern"`
+	DirectoryPattern []string `yaml:"directory_pattern"`
 
 	// CustomFields are the custom fields that can be used in document templates.
 	// At this level, these are the custom fields that are available to only this document type.

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -132,7 +132,7 @@ func deepMergeConfig(dst, src *Config) {
 			if v.FileNamePattern != "" {
 				existing.FileNamePattern = v.FileNamePattern
 			}
-			if v.DirectoryPattern != "" {
+			if len(v.DirectoryPattern) > 0 {
 				existing.DirectoryPattern = v.DirectoryPattern
 			}
 			if existing.CustomFields == nil {

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -19,7 +19,9 @@ document_types:
   markdown:
     template_file: "default.md"
     file_name_pattern: "{{ .DocType }}.md"
-    directory_pattern: "{{ .Today | date \"2006\"}}/{{ .Today | date \"Jan\" }}"
+    directory_pattern:
+        - "{{ .Today | date \"2006\"}}"
+        - "{{ .Today | date \"Jan\" }}"
 `
 
 	filePath := filepath.Join(tempDir, "config.yaml")
@@ -36,7 +38,7 @@ document_types:
 	assert.Equal(t, "Test User", config.CustomFields["author"])
 	assert.Equal(t, "default.md", config.DocumentTypes["markdown"].TemplateFile)
 	assert.Equal(t, "{{ .DocType }}.md", config.DocumentTypes["markdown"].FileNamePattern)
-	assert.Equal(t, "{{ .Today | date \"2006\"}}/{{ .Today | date \"Jan\" }}", config.DocumentTypes["markdown"].DirectoryPattern)
+	assert.Equal(t, []string{"{{ .Today | date \"2006\"}}", "{{ .Today | date \"Jan\" }}"}, config.DocumentTypes["markdown"].DirectoryPattern)
 }
 
 // TestLoadConfigurationsMultipleLayers verifies that configurations are loaded from multiple layers (and merged correctly)
@@ -88,7 +90,9 @@ custom_fields:
 document_types:
   journal:
     template_file: "user.md"
-    directory_pattern: "{{ .Today | date \"2006\" }}/{{ .Today | date \"Jan\" }}"
+    directory_pattern: [
+        "{{ .Today | date \"2006\" }}",
+        "{{ .Today | date \"Jan\" }}"]
     file_name_pattern: ".{{ .DocType }}.md"
     custom_fields:
       mood: "sad"
@@ -99,7 +103,7 @@ document_types:
   journal:
     template_file: "workspace.md"
     file_name_pattern: "workspace-{{ .DocType }}.md"
-    directory_pattern: "{{ .Today | date \"2006\" }}/workspaceoverride"
+    directory_pattern: [ "{{ .Today | date \"2006\" }}", "workspaceoverride" ]
     custom_fields:
       mood: "happy"
   planning:
@@ -128,7 +132,7 @@ document_types:
 	journalDocType := config.DocumentTypes["journal"]
 	assert.NotNil(t, journalDocType)
 	assert.Equal(t, "workspace.md", journalDocType.TemplateFile)
-	assert.Equal(t, "{{ .Today | date \"2006\" }}/workspaceoverride", journalDocType.DirectoryPattern)
+	assert.Equal(t, []string{"{{ .Today | date \"2006\" }}", "workspaceoverride"}, journalDocType.DirectoryPattern)
 	assert.Equal(t, "workspace-{{ .DocType }}.md", journalDocType.FileNamePattern)
 	assert.Equal(t, "happy", journalDocType.CustomFields["mood"])
 


### PR DESCRIPTION
Added ability to specify directory patterns using an array.

This is a breaking change and will cause errors with existing configs.

### Old config:
``` yaml
directory_pattern: "{{ .Today }}-dir/{{ .Topic }}"
```
### New config

``` yaml
directory_pattern: [ "{{ .Today }}-dir", "{{ .Topic }}" ]
```
or
``` yaml
directory_pattern: 
    - "{{ .Today }}-dir"
    - "{{ .Topic }}"
```
or
``` yaml
directory_pattern: [ "{{.Today}}-dir",
    "{{ .Topic }}" ]
```

Closes https://github.com/matthewchivers/dodl/issues/30