### PR TITLE
added ability to run --version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,8 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      - "-X github.com/matthewchivers/dodl/cmd.version={{.Version}}"
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BINARY_NAME=dodl
 PKG=./...
 PLATFORMS=linux darwin windows
 ARCHITECTURES=amd64 arm64
+VERSION ?= $(shell git describe --tags --abbrev=0)
 
 default: build
 
@@ -12,8 +13,7 @@ build: test
 		for GOARCH in $(ARCHITECTURES); do \
 			echo "Building for $$GOOS/$$GOARCH..."; \
 			mkdir -p $(BUILD_DIR) && \
-			GOOS=$$GOOS GOARCH=$$GOARCH go build -o $(BUILD_DIR)/$(BINARY_NAME)-$$GOOS-$$GOARCH; \
-		done; \
+			GOOS=$$GOOS GOARCH=$$GOARCH go build -ldflags="-X github.com/matthewchivers/dodl/cmd.version=$(VERSION)" -o $(BUILD_DIR)/$(BINARY_NAME)-$$GOOS-$$GOARCH; \		done; \
 	done
 
 test: vet

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,11 +11,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var version = "dev"
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "dodl",
-	Short: "dodl is a document creation tool",
-	Long:  `dodl is a command-line tool for creating structured documents using templates.`,
+	Use:     "dodl",
+	Version: version,
+	Short:   "dodl is a document creation tool",
+	Long:    `dodl is a command-line tool for creating structured documents using templates.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Welcome to dodl! Run 'dodl help' to get started.")
 	},


### PR DESCRIPTION
Adds ability to run the `--version` command.

Updated Makefile and goreleaser to populate the build with the current version tag.

Contributes towards https://github.com/matthewchivers/dodl/issues/27