### PR TITLE
added "weekNumber" function

### DIFF
--- a/pkg/templating/functions.go
+++ b/pkg/templating/functions.go
@@ -13,6 +13,7 @@ func addCustomFuncs(funcMap template.FuncMap) template.FuncMap {
 	funcMap["WeekStart"] = WeekStart
 	funcMap["daysInYear"] = daysInYear
 	funcMap["daysInMonth"] = daysInMonth
+	funcMap["weekNumber"] = weekNumber
 	return funcMap
 }
 
@@ -50,4 +51,11 @@ func daysInYear(t time.Time) int {
 // e.g. 31 for January, 28 for February (non-leap year), 29 for February (leap year).
 func daysInMonth(t time.Time) int {
 	return time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, t.Location()).Day()
+}
+
+// weekNumber returns the week number of the given date.
+// The week number is defined as the ISO 8601 week number.
+func weekNumber(t time.Time) int {
+	_, week := t.ISOWeek()
+	return week
 }

--- a/pkg/templating/functions_test.go
+++ b/pkg/templating/functions_test.go
@@ -253,3 +253,42 @@ func TestDaysInMonth(t *testing.T) {
 		})
 	}
 }
+
+// TestWeekNumber tests the weekNumber function.
+func TestWeekNumber(t *testing.T) {
+	testCases := []struct {
+		name     string
+		date     time.Time
+		expected int
+	}{
+		{
+			name:     "ISO week 1",
+			date:     time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
+			expected: 52,
+		},
+		{
+			name:     "ISO week 2",
+			date:     time.Date(2023, time.January, 8, 0, 0, 0, 0, time.UTC),
+			expected: 1,
+		},
+		{
+			name:     "ISO week 53",
+			date:     time.Date(2023, time.December, 31, 0, 0, 0, 0, time.UTC),
+			expected: 52,
+		},
+		{
+			name:     "ISO week 1 in leap year",
+			date:     time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
+			expected: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := weekNumber(tc.date)
+			if result != tc.expected {
+				t.Errorf("Expected %d, got %d", tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/templating/templating_test.go
+++ b/pkg/templating/templating_test.go
@@ -66,6 +66,12 @@ func TestRenderTemplate_DirectoryPatterns(t *testing.T) {
 			testTime: time.Date(2024, time.October, 29, 0, 0, 0, 0, time.UTC),
 			expected: "28 Oct to 03 Nov",
 		},
+		{
+			name:     "Week number",
+			template: "Week {{ .Now | weekNumber }}",
+			testTime: time.Date(2024, time.October, 29, 0, 0, 0, 0, time.UTC),
+			expected: "Week 44",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Added `weekNumber()` function to provide the ISO 8601 week number to templates.
> Week ranges from 1 to 53. Jan 01 to Jan 03 of year n might belong to week 52 or 53 of year n-1, and Dec 29 to Dec 31 might belong to week 1 of year n+1.