### PR TITLE
Fix WeekStart

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -64,17 +64,18 @@ func runCreateE(args []string, wdProv wd.WorkingDirProvider) error {
 		return fmt.Errorf("document type %s not found in configuration", docTypeName)
 	}
 
-	startTime := time.Now()
+	refTime := time.Now()
 	if dateStr != "" {
-		startTime, err = time.Parse("02-01-2006", dateStr)
+		refTime, err = time.Parse("02-01-2006", dateStr)
 		if err != nil {
 			return fmt.Errorf("failed to parse date: %w", err)
 		}
 	}
 
 	appCtx := &core.AppContext{
-		WorkingDir: workingDir,
-		StartTime:  startTime,
+		WorkingDir:    workingDir,
+		StartTime:     time.Now(),
+		ReferenceTime: refTime,
 	}
 
 	createCmd := core.CreateCommand{

--- a/internal/core/appctx.go
+++ b/internal/core/appctx.go
@@ -7,6 +7,12 @@ import (
 // AppContext contains the context for the application - purely the "context" in which the application is running.
 // This may be expanded, but should not include "calculated" values - just the raw context.
 type AppContext struct {
+	// WorkingDir is the working directory of the application.
 	WorkingDir string
-	StartTime  time.Time
+
+	// StartTime is the time that the application started.
+	StartTime time.Time
+
+	// ReferenceTime is the time that is used as the reference point for the application.
+	ReferenceTime time.Time
 }

--- a/internal/core/create.go
+++ b/internal/core/create.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/matthewchivers/dodl/pkg/config"
+	"github.com/matthewchivers/dodl/pkg/dateutils"
 	"github.com/matthewchivers/dodl/pkg/filesystem"
 	"github.com/matthewchivers/dodl/pkg/templating"
 	"github.com/matthewchivers/dodl/pkg/validation"
@@ -23,9 +24,12 @@ type CreateCommand struct {
 
 // Execute creates a new document based on the data/context in the CreateCommand
 func (c *CreateCommand) Execute() error {
+	refTime := c.AppCtx.ReferenceTime
+
 	data := map[string]interface{}{
-		"Today": c.AppCtx.StartTime,
-		"Topic": c.Topic,
+		"Today":     refTime,
+		"Topic":     c.Topic,
+		"WeekStart": dateutils.GetDefaultWeekStartDate(refTime),
 	}
 
 	data["DocName"] = c.DocName
@@ -38,7 +42,7 @@ func (c *CreateCommand) Execute() error {
 		data[k] = v
 	}
 
-	filename, err := templating.RenderTemplate(c.DocType.FileNamePattern, data)
+	filename, err := templating.RenderTemplate(c.DocType.FileNamePattern, data, refTime)
 	if err != nil {
 		return err
 	}
@@ -48,7 +52,7 @@ func (c *CreateCommand) Execute() error {
 
 	dirParts := []string{}
 	for _, part := range c.DocType.DirectoryPattern {
-		dirPart, err := templating.RenderTemplate(part, data)
+		dirPart, err := templating.RenderTemplate(part, data, refTime)
 		if err != nil {
 			return err
 		}
@@ -63,7 +67,7 @@ func (c *CreateCommand) Execute() error {
 	if err != nil {
 		return err
 	}
-	content, err := templating.RenderTemplate(string(templateData), data)
+	content, err := templating.RenderTemplate(string(templateData), data, refTime)
 	if err != nil {
 		return err
 	}

--- a/internal/core/create_test.go
+++ b/internal/core/create_test.go
@@ -34,10 +34,11 @@ AnotherField: {{ .AnotherField }}`
 }
 
 // createMockAppContext creates a mock application context for testing
-func createMockAppContext(testDir string, mockStartTime time.Time) *AppContext {
+func createMockAppContext(testDir string, mockReferenceTime time.Time) *AppContext {
 	return &AppContext{
-		WorkingDir: testDir,
-		StartTime:  mockStartTime,
+		WorkingDir:    testDir,
+		StartTime:     time.Now(),
+		ReferenceTime: mockReferenceTime,
 	}
 }
 
@@ -86,10 +87,10 @@ func TestCreateCommand_Execute(t *testing.T) {
 	setupTestEnvironment(t, testDir)
 
 	mockDate := "2024-10-29"
-	mockStartTime, err := time.Parse("2006-01-02", mockDate)
+	mockReferenceTime, err := time.Parse("2006-01-02", mockDate)
 	require.NoError(t, err)
 
-	appCtx := createMockAppContext(testDir, mockStartTime)
+	appCtx := createMockAppContext(testDir, mockReferenceTime)
 	docType := createMockDocumentType()
 	wsp, err := workspace.NewWorkspace(testDir)
 	require.NoError(t, err)
@@ -97,14 +98,14 @@ func TestCreateCommand_Execute(t *testing.T) {
 
 	require.NoError(t, cmd.Execute(), "Failed to execute create command")
 
-	expectedDirPath := filepath.Join(testDir, "docs", mockStartTime.Format("2006"), mockStartTime.Format("January"))
-	expectedFilePath := filepath.Join(expectedDirPath, fmt.Sprintf("%s-TestDocument.md", mockStartTime.Format("2006-01-02")))
+	expectedDirPath := filepath.Join(testDir, "docs", mockReferenceTime.Format("2006"), mockReferenceTime.Format("January"))
+	expectedFilePath := filepath.Join(expectedDirPath, fmt.Sprintf("%s-TestDocument.md", mockReferenceTime.Format("2006-01-02")))
 
 	expectedContent := fmt.Sprintf(`Document Title: TestDocument
 Date: %s
 Topic: Test Topic
 CustomField: Example Custom Field
-AnotherField: Additional Field`, mockStartTime.Format("02-01-2006"))
+AnotherField: Additional Field`, mockReferenceTime.Format("02-01-2006"))
 
 	verifyGeneratedDocument(t, expectedDirPath, expectedFilePath, expectedContent)
 }

--- a/pkg/dateutils/date.go
+++ b/pkg/dateutils/date.go
@@ -1,0 +1,54 @@
+package dateutils
+
+import "time"
+
+// AddDays adds a number of days to a time.Time object.
+// If the number of days is negative, the days are subtracted.
+func AddDays(t time.Time, days int) time.Time {
+	return t.AddDate(0, 0, days)
+}
+
+// AddMonths adds a number of months to a time.Time object.
+// If the number of months is negative, the months are subtracted.
+func AddMonths(t time.Time, months int) time.Time {
+	return t.AddDate(0, months, 0)
+}
+
+// AddYears adds a number of years to a time.Time object.
+// If the number of years is negative, the years are subtracted.
+func AddYears(t time.Time, years int) time.Time {
+	return t.AddDate(years, 0, 0)
+}
+
+// GetWeekStartDate returns the date of the start of the week containing the given time,
+// based on the startDay provided. The startDay should be one of the time.Weekday constants.
+func GetWeekStartDate(t time.Time, startDay time.Weekday) time.Time {
+	// Calculate the offset based on the start day
+	offset := (int(t.Weekday()) - int(startDay) + 7) % 7
+	return t.AddDate(0, 0, -offset)
+}
+
+// GetDefaultWeekStartDate returns the date of the start of the week containing the given time,
+// based on the default start day (Monday).
+func GetDefaultWeekStartDate(t time.Time) time.Time {
+	return GetWeekStartDate(t, time.Monday)
+}
+
+// DaysInYear returns the number of days in the year of the given date.
+// e.g. 365 for a non-leap year, 366 for a leap year.
+func DaysInYear(t time.Time) int {
+	return time.Date(t.Year()+1, 1, 0, 0, 0, 0, 0, t.Location()).YearDay()
+}
+
+// DaysInMonth returns the number of days in the month of the given date.
+// e.g. 31 for January, 28 for February (non-leap year), 29 for February (leap year).
+func DaysInMonth(t time.Time) int {
+	return time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, t.Location()).Day()
+}
+
+// WeekNumber returns the week number of the given date.
+// The week number is defined as the ISO 8601 week number.
+func WeekNumber(t time.Time) int {
+	_, week := t.ISOWeek()
+	return week
+}

--- a/pkg/dateutils/date_test.go
+++ b/pkg/dateutils/date_test.go
@@ -1,4 +1,4 @@
-package templating
+package dateutils
 
 import (
 	"testing"
@@ -41,7 +41,7 @@ func TestAddDays(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := addDays(tc.start, tc.days)
+			result := AddDays(tc.start, tc.days)
 			if !result.Equal(tc.expected) {
 				t.Errorf("Expected %v, got %v", tc.expected, result)
 			}
@@ -85,7 +85,7 @@ func TestAddMonths(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := addMonths(tc.start, tc.months)
+			result := AddMonths(tc.start, tc.months)
 			if !result.Equal(tc.expected) {
 				t.Errorf("Expected %v, got %v", tc.expected, result)
 			}
@@ -129,7 +129,7 @@ func TestAddYears(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := addYears(tc.start, tc.years)
+			result := AddYears(tc.start, tc.years)
 			if !result.Equal(tc.expected) {
 				t.Errorf("Expected %v, got %v", tc.expected, result)
 			}
@@ -164,11 +164,16 @@ func TestWeekStart(t *testing.T) {
 			date:     time.Date(2024, time.December, 31, 0, 0, 0, 0, time.UTC),
 			expected: time.Date(2024, time.December, 30, 0, 0, 0, 0, time.UTC),
 		},
+		{
+			name:     "Beginning of year",
+			date:     time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
+			expected: time.Date(2024, time.December, 30, 0, 0, 0, 0, time.UTC),
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := WeekStart(tc.date)
+			result := GetDefaultWeekStartDate(tc.date)
 			if !result.Equal(tc.expected) {
 				t.Errorf("Expected %v, got %v", tc.expected, result)
 			}
@@ -207,7 +212,7 @@ func TestDaysInYear(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := daysInYear(tc.date)
+			result := DaysInYear(tc.date)
 			if result != tc.expected {
 				t.Errorf("Expected %d, got %d", tc.expected, result)
 			}
@@ -246,7 +251,7 @@ func TestDaysInMonth(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := daysInMonth(tc.date)
+			result := DaysInMonth(tc.date)
 			if result != tc.expected {
 				t.Errorf("Expected %d, got %d", tc.expected, result)
 			}
@@ -285,7 +290,7 @@ func TestWeekNumber(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := weekNumber(tc.date)
+			result := WeekNumber(tc.date)
 			if result != tc.expected {
 				t.Errorf("Expected %d, got %d", tc.expected, result)
 			}

--- a/pkg/templating/functions.go
+++ b/pkg/templating/functions.go
@@ -1,61 +1,18 @@
 package templating
 
 import (
-	"time"
-
 	"text/template"
+
+	"github.com/matthewchivers/dodl/pkg/dateutils"
 )
 
 func addCustomFuncs(funcMap template.FuncMap) template.FuncMap {
-	funcMap["addDays"] = addDays
-	funcMap["addMonths"] = addMonths
-	funcMap["addYears"] = addYears
-	funcMap["WeekStart"] = WeekStart
-	funcMap["daysInYear"] = daysInYear
-	funcMap["daysInMonth"] = daysInMonth
-	funcMap["weekNumber"] = weekNumber
+	funcMap["addDays"] = dateutils.AddDays
+	funcMap["addMonths"] = dateutils.AddMonths
+	funcMap["addYears"] = dateutils.AddYears
+	funcMap["calcWeekStart"] = dateutils.GetDefaultWeekStartDate
+	funcMap["daysInYear"] = dateutils.DaysInYear
+	funcMap["daysInMonth"] = dateutils.DaysInMonth
+	funcMap["weekNumber"] = dateutils.WeekNumber
 	return funcMap
-}
-
-// addDays adds a number of days to a time.Time object.
-// If the number of days is negative, the days are subtracted.
-func addDays(t time.Time, days int) time.Time {
-	return t.AddDate(0, 0, days)
-}
-
-// addMonths adds a number of months to a time.Time object.
-// If the number of months is negative, the months are subtracted.
-func addMonths(t time.Time, months int) time.Time {
-	return t.AddDate(0, months, 0)
-}
-
-// addYears adds a number of years to a time.Time object.
-// If the number of years is negative, the years are subtracted.
-func addYears(t time.Time, years int) time.Time {
-	return t.AddDate(years, 0, 0)
-}
-
-// WeekStart returns the date of the Monday of the week containing the given t (time.Time).
-func WeekStart(t time.Time) time.Time {
-	offset := (int(t.Weekday()) + 6) % 7 // Adjust so that Monday is 0
-	return t.AddDate(0, 0, -offset)
-}
-
-// daysInYear returns the number of days in the year of the given date.
-// e.g. 365 for a non-leap year, 366 for a leap year.
-func daysInYear(t time.Time) int {
-	return time.Date(t.Year()+1, 1, 0, 0, 0, 0, 0, t.Location()).YearDay()
-}
-
-// daysInMonth returns the number of days in the month of the given date.
-// e.g. 31 for January, 28 for February (non-leap year), 29 for February (leap year).
-func daysInMonth(t time.Time) int {
-	return time.Date(t.Year(), t.Month()+1, 0, 0, 0, 0, 0, t.Location()).Day()
-}
-
-// weekNumber returns the week number of the given date.
-// The week number is defined as the ISO 8601 week number.
-func weekNumber(t time.Time) int {
-	_, week := t.ISOWeek()
-	return week
 }

--- a/pkg/templating/templating.go
+++ b/pkg/templating/templating.go
@@ -3,13 +3,20 @@ package templating
 import (
 	"bytes"
 	"text/template"
+	"time"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/matthewchivers/dodl/pkg/dateutils"
 )
 
 // RenderTemplate renders a template string using the provided data map.
 // It returns the rendered string or an error if rendering fails.
-func RenderTemplate(templateStr string, data map[string]interface{}) (string, error) {
+func RenderTemplate(templateStr string, data map[string]interface{}, date time.Time) (string, error) {
+
+	data["Now"] = date
+	data["Today"] = date
+	data["WeekStart"] = dateutils.GetDefaultWeekStartDate(date)
+
 	funcMap := sprig.TxtFuncMap()
 	funcMap = addCustomFuncs(funcMap)
 


### PR DESCRIPTION
## Description:
This PR addresses the issue where the {{ .WeekStart }} placeholder was incorrectly returning the Tuesday of the current week, regardless of the input date. The problem arose from how the placeholder was calculating the start of the week based on the current reference date.

## Changes:

* weekStart: Added as a function placeholder to calculate the start of the week dynamically based on a provided date. This allows users to pass in any date and calculate the corresponding start of the week (Monday).
    * Example usage: `{{ .Now | weekStart | date "02-01-2006" }}`
* WeekStart: A new standalone placeholder that returns the start of the week (Monday) based on the reference date used by the application. This provides a consistent start of the week without needing to pass any parameters.
    * Example usage: `{{ .WeekStart }}`